### PR TITLE
Update documentation on KafkaListener annotation

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -93,6 +93,8 @@ public @interface KafkaListener {
 	/**
 	 * The unique identifier of the container managing for this endpoint.
 	 * <p>If none is specified an auto-generated one is provided.
+	 * <p>Note: When provided, this value will override the group id property
+	 * in the consumer factory configuration, unless {@link #idIsGroup()} is set to false.
 	 * @return the {@code id} for the container managing for this endpoint.
 	 * @see org.springframework.kafka.config.KafkaListenerEndpointRegistry#getListenerContainer(String)
 	 */


### PR DESCRIPTION
Expand id documentation to clarify that it will override the group id specified in the configuration by default.